### PR TITLE
Added test table teardown

### DIFF
--- a/src/test/java/com/rqlite/RqliteClientTest.java
+++ b/src/test/java/com/rqlite/RqliteClientTest.java
@@ -31,6 +31,8 @@ public class RqliteClientTest {
         Assert.assertArrayEquals(new String[] { "integer", "text" }, rows.results[0].types);
         Assert.assertEquals(1, rows.results[0].values.length);
         Assert.assertArrayEquals(new Object[] { new BigDecimal(1), "fiona" }, rows.results[0].values[0]);
+        
+        rqlite.Execute("DROP TABLE foo");
     }
 
     @Test
@@ -69,6 +71,8 @@ public class RqliteClientTest {
         Assert.assertEquals(2, rows.results[1].values.length);
         Assert.assertArrayEquals(new Object[] { "fiona" }, rows.results[1].values[0]);
         Assert.assertArrayEquals(new Object[] { "declan" }, rows.results[1].values[1]);
+        
+        rqlite.Execute("DROP TABLE bar");
     }
 
     @Test


### PR DESCRIPTION
Dropping tables at the end of the test facilitates repeated runs of the tests.